### PR TITLE
✨ Add manual PR sync functionality

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -21,6 +21,7 @@ func SetupRoutes(router *gin.Engine, db *sql.DB, syncService *service.SyncServic
 	{
 		api.GET("/prs", handlers.GetPRs)
 		api.GET("/prs/:id", handlers.GetPR)
+		api.POST("/prs/:id/sync", syncHandler.SyncPR)
 
 		api.POST("/sync", syncHandler.Sync)
 		api.GET("/sync/status", syncHandler.GetSyncStatus)

--- a/web/src/pages/Detail.tsx
+++ b/web/src/pages/Detail.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router-dom";
-import { getPR } from "../services/api";
+import { getPR, syncPR } from "../services/api";
 import StatusBadge from "../components/StatusBadge";
+import ManualSyncButton from "../components/ManualSyncButton";
 
 interface Summary {
   description_summary?: string;
@@ -65,6 +66,16 @@ export default function Detail() {
     }
   };
 
+  const handleSync = async () => {
+    if (!id) return;
+    try {
+      await syncPR(parseInt(id));
+      setTimeout(loadData, 2000); // 2秒後に再読み込み
+    } catch (error) {
+      console.error("同期に失敗しました", error);
+    }
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen bg-white flex items-center justify-center">
@@ -103,9 +114,12 @@ export default function Detail() {
         <div className="mb-12">
           <div className="flex items-center gap-3 mb-6">
             <StatusBadge state={data.state} alwaysColored={true} />
-            <h1 className="text-3xl font-light text-gray-900 tracking-tight">
+            <h1 className="text-3xl font-light text-gray-900 tracking-tight flex-1">
               {data.title}
             </h1>
+            <div className="flex-shrink-0">
+              <ManualSyncButton onSync={handleSync} />
+            </div>
           </div>
 
           <div className="prose max-w-none mb-8">

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -30,6 +30,11 @@ export const sync = async () => {
   return response.data
 }
 
+export const syncPR = async (id: number) => {
+  const response = await api.post(`/prs/${id}/sync`)
+  return response.data
+}
+
 export const getSyncStatus = async () => {
   const response = await api.get('/sync/status')
   return response.data


### PR DESCRIPTION
## Overview

個別PRの手動同期機能を追加しました。Detailページから特定のPRを手動で再同期できるようになります。

## Purpose

- 特定のPRのデータを手動で更新したい場合に、全体同期を待たずに即座に同期できるようにする
- ユーザーが個別にPRの状態を最新化できるUIを提供する

## Implementation Summary

### Backend
- 個別PR同期エンドポイント追加: `POST /api/v1/prs/:id/sync`
- `SyncPR` ハンドラー実装（同時実行制御と10分タイムアウト付き）
- `SyncPRByID` サービスメソッド追加（データベースIDからPR情報を取得してGitHubから最新データを取得・保存）

### Frontend
- Detailページに手動同期ボタンを追加
- `syncPR` API関数を追加
- 同期後、2秒後に自動的にデータを再読み込み

## Changes Result

- DetailページのPRタイトル横に同期ボタンが表示される
- ボタンクリックで即座にPRの同期が開始される
- 同期完了後、自動的にページが更新される

## Areas for Review

- 同時実行制御の実装が適切か（セマフォによる制限）
- タイムアウト時間（10分）が適切か
- エラーハンドリングが適切か
- UIの配置やデザインが適切か

## Notes

- 同期処理は非同期で実行されるため、HTTPレスポンスは即座に返される
- 同時実行数の上限に達している場合は、429エラーが返される
- 同期処理は最大10分でタイムアウトする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added manual synchronization capability for individual pull requests. Users can now trigger an immediate sync of pull request data from the PR detail page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->