### PR TITLE
:memo: Translate Go skills documentation to English

### DIFF
--- a/.claude/commands/go-explain.md
+++ b/.claude/commands/go-explain.md
@@ -1,70 +1,85 @@
 ---
-description: Goコードの動作と設計意図を解説
+description: Explain Go code behavior and design intent
 allowed-tools: Read, Grep, Glob
 argument-hint: <file-path or code-snippet>
 ---
 
 # Go Code Explain
 
-## 対象
+## Target
 
 $ARGUMENTS
 
-## 解説手順
+## Explanation Process
 
-1. 対象コードを読み込む
-2. Go の設計思想に基づいて解説
-3. 以下の観点で説明
+1. Read the target code
+2. Explain based on Go's design philosophy
+3. Explain from the following perspectives
 
-## 解説の観点
+## Explanation Perspectives
 
-### 1. 概要
-- このコードは何をしているか
-- なぜこのように実装されているか（Go の思想との関連）
+### 1. Overview
 
-### 2. 詳細解説
-- 各部分の役割と動作
-- 使用されているパターンやイディオム
-- 重要な Go の機能（interface, goroutine, channel など）
+- What does this code do?
+- Why is it implemented this way? (Relationship with Go's philosophy)
 
-### 3. 設計のポイント
-- なぜこの設計が選ばれたか
-- 代替案との比較
-- トレードオフ
+### 2. Detailed Explanation
 
-### 4. 学習ポイント
-- このコードから学べる Go のベストプラクティス
-- 関連する Go Proverbs
-- 参考にすべきスキル
+- Role and behavior of each part
+- Patterns and idioms used
+- Important Go features (interface, goroutine, channel, etc.)
 
-## 出力フォーマット
+### 3. Design Points
 
-```markdown
-## コード解説: [対象]
+- Why was this design chosen?
+- Comparison with alternatives
+- Trade-offs
 
-### 概要
-このコードは...
+### 4. Learning Points
 
-### 詳細解説
+- Go best practices that can be learned from this code
+- Related Go Proverbs
+- Skills to reference
 
-#### [セクション1]
+## Output Format
+
+````markdown
+## Code Explanation: [Target]
+
+### Overview
+
+This code...
+
+### Detailed Explanation
+
+#### [Section 1]
+
 ```go
-// 該当コード
+// Relevant code
 ```
-この部分は...
+````
 
-#### [セクション2]
+This part...
+
+#### [Section 2]
+
 ...
 
-### 設計のポイント
-- **なぜこの設計か**: ...
-- **Go の思想との関連**: ...
+### Design Points
 
-### 学習ポイント
-1. **[ポイント1]**: ...
-2. **[ポイント2]**: ...
+- **Why this design**: ...
+- **Relationship with Go's philosophy**: ...
 
-### 関連するスキル
+### Learning Points
+
+1. **[Point 1]**: ...
+2. **[Point 2]**: ...
+
+### Related Skills
+
 - go-philosophy: ...
 - go-error-handling: ...
+
+```
+
 ```

--- a/.claude/commands/go-review.md
+++ b/.claude/commands/go-review.md
@@ -1,61 +1,73 @@
 ---
-description: Goコードをレビューし、改善点を提案
+description: Review Go code and suggest improvements
 allowed-tools: Read, Grep, Glob
 argument-hint: <file-path>
 ---
 
 # Go Code Review
 
-## 対象ファイル
+## Target File
 
 $ARGUMENTS
 
-## レビュー手順
+## Review Process
 
-1. 対象ファイルを読み込む
-2. go-code-review スキルに基づいてレビュー
-3. 以下の観点で問題点と改善案を提示
+1. Read the target file
+2. Review based on go-code-review skill
+3. Present issues and improvements from the following perspectives
 
-## レビュー観点
+## Review Perspectives
 
-### 必須チェック項目
-- [ ] エラーは適切に処理されているか
-- [ ] リソース（ファイル、接続）は適切にクローズされているか
-- [ ] 並行処理は安全か（データ競合、goroutine リーク）
-- [ ] 入力検証は行われているか
+### Required Check Items
 
-### コードスタイル
-- [ ] 命名は明確か
-- [ ] 関数は適切な長さか
-- [ ] 早期リターンを使っているか
-- [ ] コメントは適切か
+- [ ] Are errors handled appropriately?
+- [ ] Are resources (files, connections) properly closed?
+- [ ] Is concurrency safe? (data races, goroutine leaks)
+- [ ] Is input validation performed?
 
-### パフォーマンス
-- [ ] 不要なメモリ割り当てはないか
-- [ ] 大きな構造体はポインタで渡しているか
+### Code Style
 
-### セキュリティ
-- [ ] SQL インジェクション対策
-- [ ] 機密情報のログ出力チェック
+- [ ] Are names clear?
+- [ ] Are functions appropriately sized?
+- [ ] Is early return used?
+- [ ] Are comments appropriate?
 
-## 出力フォーマット
+### Performance
 
-```markdown
-## レビュー結果: [ファイル名]
+- [ ] Are there unnecessary memory allocations?
+- [ ] Are large structs passed by pointer?
 
-### 良い点
+### Security
+
+- [ ] SQL injection prevention
+- [ ] Check for logging sensitive information
+
+## Output Format
+
+````markdown
+## Review Results: [File Name]
+
+### Good Points
+
 - ...
 
-### 改善が必要な点
+### Points Needing Improvement
 
-#### 1. [問題の概要] (優先度: 高/中/低)
-**場所**: 行 XX
-**問題**: ...
-**改善案**:
+#### 1. [Issue Summary] (Priority: High/Medium/Low)
+
+**Location**: Line XX
+**Issue**: ...
+**Improvement**:
+
 ```go
-// 改善後のコード
+// Improved code
+```
+````
+
+### Overall Comments
+
+...
+
 ```
 
-### 全体的なコメント
-...
 ```

--- a/.claude/skills/go-code-review/SKILL.md
+++ b/.claude/skills/go-code-review/SKILL.md
@@ -1,65 +1,65 @@
 ---
 name: go-code-review
-description: Goコードレビューのチェックリストとベストプラクティス。コードレビュー時、PRレビュー時、コード品質改善時に使用。
+description: Checklist and best practices for Go code review. Use when reviewing code, PRs, or improving code quality.
 ---
 
-# Go コードレビューガイド
+# Go Code Review Guide
 
-## レビューの優先順位
+## Review Priority
 
-1. **正確性** - 正しく動作するか
-2. **セキュリティ** - 脆弱性はないか
-3. **パフォーマンス** - 効率的か
-4. **可読性** - 理解しやすいか
-5. **保守性** - 変更しやすいか
+1. **Correctness** - Does it work correctly?
+2. **Security** - Are there vulnerabilities?
+3. **Performance** - Is it efficient?
+4. **Readability** - Is it easy to understand?
+5. **Maintainability** - Is it easy to modify?
 
-## 必須チェック項目
+## Required Check Items
 
-### 1. エラーハンドリング
+### 1. Error Handling
 
 ```go
-// Check: エラーは無視されていないか
+// Check: Are errors not ignored?
 result, err := doSomething()
 if err != nil {
-    return err  // または適切に処理
+    return err  // or handle appropriately
 }
 
-// Check: エラーメッセージにコンテキストがあるか
+// Check: Do error messages have context?
 return fmt.Errorf("fetch user %s: %w", id, err)
 
-// Check: sentinel errors は errors.Is で比較しているか
+// Check: Are sentinel errors compared with errors.Is?
 if errors.Is(err, ErrNotFound) {
     // ...
 }
 ```
 
-### 2. リソース管理
+### 2. Resource Management
 
 ```go
-// Check: Close() は defer で確実に呼ばれているか
+// Check: Is Close() called reliably with defer?
 f, err := os.Open(path)
 if err != nil {
     return err
 }
 defer f.Close()
 
-// Check: HTTP Response Body はクローズされているか
+// Check: Is HTTP Response Body closed?
 resp, err := http.Get(url)
 if err != nil {
     return err
 }
 defer resp.Body.Close()
 
-// Check: database 接続はプールされているか
-// (毎回 Open() していないか)
+// Check: Are database connections pooled?
+// (Not calling Open() every time)
 ```
 
-### 3. 並行処理
+### 3. Concurrency
 
 ```go
-// Check: goroutine リークの可能性はないか
-// Check: データ競合はないか (go test -race)
-// Check: context によるキャンセルに対応しているか
+// Check: Is there a possibility of goroutine leaks?
+// Check: Are there data races? (go test -race)
+// Check: Does it handle cancellation via context?
 
 func worker(ctx context.Context) error {
     select {
@@ -70,7 +70,7 @@ func worker(ctx context.Context) error {
     }
 }
 
-// Check: WaitGroup の Add/Done の対応は正しいか
+// Check: Are WaitGroup Add/Done pairs correct?
 wg.Add(1)
 go func() {
     defer wg.Done()
@@ -78,10 +78,10 @@ go func() {
 }()
 ```
 
-### 4. 入力検証
+### 4. Input Validation
 
 ```go
-// Check: ユーザー入力は検証されているか
+// Check: Is user input validated?
 func CreateUser(name string, age int) error {
     if name == "" {
         return errors.New("name is required")
@@ -92,7 +92,7 @@ func CreateUser(name string, age int) error {
     // ...
 }
 
-// Check: SQL インジェクション対策
+// Check: SQL injection prevention
 // Avoid
 query := fmt.Sprintf("SELECT * FROM users WHERE id = '%s'", id)
 
@@ -101,15 +101,15 @@ query := "SELECT * FROM users WHERE id = ?"
 db.Query(query, id)
 ```
 
-### 5. API 設計
+### 5. API Design
 
 ```go
-// Check: 関数シグネチャは適切か
-// - context.Context は第一引数
-// - エラーは最後の戻り値
+// Check: Is the function signature appropriate?
+// - context.Context is the first argument
+// - Error is the last return value
 func GetUser(ctx context.Context, id string) (*User, error)
 
-// Check: Option パターンは適切に使われているか
+// Check: Is the Option pattern used appropriately?
 type Option func(*Config)
 
 func WithTimeout(d time.Duration) Option {
@@ -119,24 +119,24 @@ func WithTimeout(d time.Duration) Option {
 }
 ```
 
-## コードスタイル
+## Code Style
 
-### 命名
+### Naming
 
 ```go
-// Check: 変数名は明確か
+// Check: Are variable names clear?
 // Avoid
-var d int  // 何？
-var data int  // まだ不明確
+var d int  // What?
+var data int  // Still unclear
 
 // Good
 var daysSinceLastLogin int
 
-// Check: 省略形は一般的か
+// Check: Are abbreviations common?
 // OK: id, url, http, ctx, err, req, resp
-// Avoid: 独自の省略形
+// Avoid: Custom abbreviations
 
-// Check: パッケージ名と重複していないか
+// Check: Does it conflict with package name?
 // Avoid
 package user
 type User struct{}  // user.User
@@ -146,17 +146,17 @@ package user
 type Info struct{}  // user.Info
 ```
 
-### 構造
+### Structure
 
 ```go
-// Check: 関数は適切な長さか (目安: 40行以下)
-// Check: ネストは深すぎないか (目安: 3レベル以下)
+// Check: Are functions appropriately sized? (Guideline: under 40 lines)
+// Check: Is nesting too deep? (Guideline: under 3 levels)
 
-// Check: 早期リターンを使っているか
+// Check: Is early return used?
 // Avoid
 func process(x int) int {
     if x > 0 {
-        // 長い処理
+        // long process
         return result
     } else {
         return 0
@@ -168,15 +168,15 @@ func process(x int) int {
     if x <= 0 {
         return 0
     }
-    // 長い処理
+    // long process
     return result
 }
 ```
 
-### コメント
+### Comments
 
 ```go
-// Check: 公開 API にはドキュメントがあるか
+// Check: Do public APIs have documentation?
 // Package user provides user management functionality.
 package user
 
@@ -190,22 +190,22 @@ type User struct {
 // It returns ErrNotFound if the user does not exist.
 func GetByID(id string) (*User, error)
 
-// Check: コメントは「なぜ」を説明しているか
-// Avoid: 何をしているかの説明
-// i をインクリメント
+// Check: Do comments explain "why"?
+// Avoid: Explaining what it does
+// Increment i
 i++
 
-// Good: なぜそうするかの説明
-// GitHub API のレート制限を回避するため 1 秒待機
+// Good: Explaining why
+// Wait 1 second to avoid GitHub API rate limits
 time.Sleep(1 * time.Second)
 ```
 
-## パフォーマンス
+## Performance
 
-### メモリ割り当て
+### Memory Allocation
 
 ```go
-// Check: スライスの容量は事前確保されているか
+// Check: Is slice capacity pre-allocated?
 // Avoid
 var items []Item
 for _, raw := range rawItems {
@@ -218,7 +218,7 @@ for _, raw := range rawItems {
     items = append(items, parse(raw))
 }
 
-// Check: strings.Builder を使っているか
+// Check: Is strings.Builder used?
 // Avoid
 var s string
 for _, item := range items {
@@ -233,49 +233,49 @@ for _, item := range items {
 s := sb.String()
 ```
 
-### 不要なコピー
+### Unnecessary Copies
 
 ```go
-// Check: 大きな構造体はポインタで渡しているか
+// Check: Are large structs passed by pointer?
 type LargeStruct struct {
     Data [1024]byte
 }
 
-// Avoid: 値渡し（コピー発生）
+// Avoid: Pass by value (copy occurs)
 func process(s LargeStruct)
 
-// Good: ポインタ渡し
+// Good: Pass by pointer
 func process(s *LargeStruct)
 
-// Check: range でのコピーを意識しているか
+// Check: Are copies in range loops considered?
 for i := range items {
-    process(&items[i])  // コピーを避ける
+    process(&items[i])  // Avoid copy
 }
 ```
 
-## セキュリティ
+## Security
 
-### チェックリスト
+### Checklist
 
 ```go
-// [ ] SQL インジェクション対策（プレースホルダ使用）
-// [ ] XSS 対策（html/template 使用）
-// [ ] パスワードは平文で保存していない（bcrypt 等）
-// [ ] 機密情報はログに出力していない
-// [ ] HTTPS を強制している
-// [ ] CORS 設定は適切か
-// [ ] 認証・認可は正しく実装されているか
+// [ ] SQL injection prevention (use placeholders)
+// [ ] XSS prevention (use html/template)
+// [ ] Passwords not stored in plain text (use bcrypt, etc.)
+// [ ] Sensitive information not logged
+// [ ] HTTPS enforced
+// [ ] CORS settings appropriate?
+// [ ] Authentication and authorization correctly implemented?
 ```
 
 ```go
-// Check: 機密情報のログ出力
+// Check: Logging sensitive information
 // Avoid
 log.Printf("user login: %s, password: %s", user, password)
 
 // Good
 log.Printf("user login: %s", user)
 
-// Check: タイミング攻撃対策
+// Check: Timing attack prevention
 // Avoid
 if password == storedPassword {
 
@@ -283,20 +283,20 @@ if password == storedPassword {
 if subtle.ConstantTimeCompare([]byte(password), []byte(storedPassword)) == 1 {
 ```
 
-## テスト
+## Testing
 
 ```go
-// Check: テストは十分にあるか
-// Check: エッジケースはテストされているか
-// - nil 入力
-// - 空文字列
-// - 境界値
-// - エラーケース
+// Check: Are there sufficient tests?
+// Check: Are edge cases tested?
+// - nil input
+// - empty string
+// - boundary values
+// - error cases
 
-// Check: テストは独立しているか（順序依存していないか）
-// Check: テストは決定的か（time.Now() に依存していないか）
+// Check: Are tests independent? (not order-dependent)
+// Check: Are tests deterministic? (not dependent on time.Now())
 
-// Check: テストヘルパーは t.Helper() を呼んでいるか
+// Check: Do test helpers call t.Helper()?
 func assertEqual(t *testing.T, got, want int) {
     t.Helper()
     if got != want {
@@ -305,48 +305,48 @@ func assertEqual(t *testing.T, got, want int) {
 }
 ```
 
-## レビューコメントの書き方
+## How to Write Review Comments
 
-### 良いコメントの例
+### Examples of Good Comments
 
 ```
-// 提案
+// Suggestion
 Consider using `errors.Is()` here to handle wrapped errors correctly.
 
-// 質問
+// Question
 Could you explain why we need this sleep? Is there a way to use
 channels or WaitGroup instead?
 
-// 必須
+// Required
 This SQL query is vulnerable to injection. Please use parameterized queries.
 
-// 称賛
+// Praise
 Great use of table-driven tests! This makes it easy to add new cases.
 ```
 
-### 避けるべきコメント
+### Comments to Avoid
 
 ```
-// 曖昧
+// Vague
 This looks wrong.
 
-// 人格攻撃
+// Personal attack
 Who wrote this terrible code?
 
-// 過度に細かい
-Change `i` to `index` (意味のある改善でない場合)
+// Overly nitpicky
+Change `i` to `index` (when it's not a meaningful improvement)
 ```
 
-## レビュー効率化
+## Review Efficiency
 
 ```bash
-# 静的解析を活用
+# Use static analysis
 go vet ./...
 golangci-lint run
 
-# データ競合検出
+# Detect data races
 go test -race ./...
 
-# テストカバレッジ確認
+# Check test coverage
 go test -cover ./...
 ```

--- a/.claude/skills/go-concurrency/SKILL.md
+++ b/.claude/skills/go-concurrency/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: go-concurrency
-description: Goの並行処理パターンとベストプラクティス。goroutine、channel、sync パッケージ、context について質問されたときに使用。
+description: Go concurrency patterns and best practices. Use when asked about goroutines, channels, sync package, or context.
 ---
 
-# Go 並行処理パターン
+# Go Concurrency Patterns
 
-## 基本原則
+## Basic Principles
 
 ### "Don't communicate by sharing memory, share memory by communicating"
 
 ```go
-// Avoid: 共有メモリ
+// Avoid: Shared memory
 var (
     data   map[string]int
     mu     sync.Mutex
@@ -22,7 +22,7 @@ func update(key string, value int) {
     mu.Unlock()
 }
 
-// Good: チャネルで通信
+// Good: Communicate via channels
 type update struct {
     key   string
     value int
@@ -36,20 +36,20 @@ func manager(updates <-chan update) {
 }
 ```
 
-## Goroutine パターン
+## Goroutine Patterns
 
-### 基本的な起動
+### Basic Launch
 
 ```go
-// 引数を渡す
+// Pass arguments
 for _, item := range items {
-    item := item  // ループ変数をキャプチャ
+    item := item  // Capture loop variable
     go func() {
         process(item)
     }()
 }
 
-// または引数として渡す
+// Or pass as argument
 for _, item := range items {
     go func(item Item) {
         process(item)
@@ -57,7 +57,7 @@ for _, item := range items {
 }
 ```
 
-### WaitGroup で待機
+### Wait with WaitGroup
 
 ```go
 func processAll(items []Item) {
@@ -71,38 +71,38 @@ func processAll(items []Item) {
         }(item)
     }
 
-    wg.Wait()  // 全完了を待機
+    wg.Wait()  // Wait for all to complete
 }
 ```
 
-## Channel パターン
+## Channel Patterns
 
-### 基本操作
+### Basic Operations
 
 ```go
-// unbuffered channel（同期）
+// unbuffered channel (synchronous)
 ch := make(chan int)
 
-// buffered channel（非同期）
+// buffered channel (asynchronous)
 ch := make(chan int, 10)
 
-// 送信
+// Send
 ch <- 42
 
-// 受信
+// Receive
 value := <-ch
 
-// クローズ
+// Close
 close(ch)
 
-// クローズ確認
+// Check if closed
 value, ok := <-ch
 if !ok {
-    // channel はクローズされている
+    // channel is closed
 }
 ```
 
-### Generator パターン
+### Generator Pattern
 
 ```go
 func generate(nums ...int) <-chan int {
@@ -116,7 +116,7 @@ func generate(nums ...int) <-chan int {
     return out
 }
 
-// 使用
+// Usage
 for n := range generate(1, 2, 3, 4, 5) {
     fmt.Println(n)
 }
@@ -125,7 +125,7 @@ for n := range generate(1, 2, 3, 4, 5) {
 ### Fan-out / Fan-in
 
 ```go
-// Fan-out: 複数のワーカーに分散
+// Fan-out: Distribute to multiple workers
 func fanOut(in <-chan int, workers int) []<-chan int {
     outs := make([]<-chan int, workers)
     for i := 0; i < workers; i++ {
@@ -145,7 +145,7 @@ func worker(in <-chan int) <-chan int {
     return out
 }
 
-// Fan-in: 複数のチャネルを1つに集約
+// Fan-in: Aggregate multiple channels into one
 func fanIn(channels ...<-chan int) <-chan int {
     var wg sync.WaitGroup
     out := make(chan int)
@@ -199,9 +199,9 @@ func square(in <-chan int) <-chan int {
 }
 ```
 
-## Select パターン
+## Select Patterns
 
-### 複数チャネルの待機
+### Waiting on Multiple Channels
 
 ```go
 select {
@@ -216,7 +216,7 @@ default:
 }
 ```
 
-### タイムアウト
+### Timeout
 
 ```go
 select {
@@ -227,14 +227,14 @@ case <-time.After(5 * time.Second):
 }
 ```
 
-### キャンセル
+### Cancellation
 
 ```go
 func worker(ctx context.Context, jobs <-chan Job) {
     for {
         select {
         case <-ctx.Done():
-            return  // キャンセルされた
+            return  // Cancelled
         case job := <-jobs:
             process(job)
         }
@@ -242,9 +242,9 @@ func worker(ctx context.Context, jobs <-chan Job) {
 }
 ```
 
-## Context パターン
+## Context Patterns
 
-### キャンセル伝播
+### Cancellation Propagation
 
 ```go
 func main() {
@@ -253,7 +253,7 @@ func main() {
 
     go worker(ctx)
 
-    // シグナルでキャンセル
+    // Cancel on signal
     sigCh := make(chan os.Signal, 1)
     signal.Notify(sigCh, syscall.SIGINT)
     <-sigCh
@@ -273,7 +273,7 @@ func worker(ctx context.Context) {
 }
 ```
 
-### タイムアウト付きコンテキスト
+### Context with Timeout
 
 ```go
 func fetchData(ctx context.Context) error {
@@ -286,7 +286,7 @@ func fetchData(ctx context.Context) error {
 }
 ```
 
-### 値の伝播
+### Value Propagation
 
 ```go
 type ctxKey string
@@ -305,7 +305,7 @@ func getRequestID(ctx context.Context) string {
 }
 ```
 
-## sync パッケージ
+## sync Package
 
 ### Mutex
 
@@ -408,7 +408,7 @@ func workerPool(jobs <-chan Job, results chan<- Result, workers int) {
 }
 ```
 
-## Semaphore パターン
+## Semaphore Pattern
 
 ```go
 type Semaphore chan struct{}
@@ -425,8 +425,8 @@ func (s Semaphore) Release() {
     <-s
 }
 
-// 使用例
-sem := NewSemaphore(10)  // 最大10並列
+// Usage example
+sem := NewSemaphore(10)  // Max 10 concurrent
 
 for _, item := range items {
     sem.Acquire()
@@ -437,21 +437,21 @@ for _, item := range items {
 }
 ```
 
-## アンチパターン
+## Anti-patterns
 
-### 1. Goroutine リーク
+### 1. Goroutine Leak
 
 ```go
-// Avoid: チャネルが受信されないと goroutine がリーク
+// Avoid: Goroutine leaks if channel is never received
 func leak() <-chan int {
     ch := make(chan int)
     go func() {
-        ch <- expensiveComputation()  // 永遠にブロック
+        ch <- expensiveComputation()  // Blocks forever
     }()
     return ch
 }
 
-// Good: context でキャンセル可能に
+// Good: Cancellable with context
 func noLeak(ctx context.Context) <-chan int {
     ch := make(chan int)
     go func() {
@@ -464,15 +464,15 @@ func noLeak(ctx context.Context) <-chan int {
 }
 ```
 
-### 2. データ競合
+### 2. Data Race
 
 ```go
-// Avoid: データ競合
+// Avoid: Data race
 var counter int
 go func() { counter++ }()
 go func() { counter++ }()
 
-// Good: 適切な同期
+// Good: Proper synchronization
 var (
     counter int
     mu      sync.Mutex

--- a/.claude/skills/go-philosophy/SKILL.md
+++ b/.claude/skills/go-philosophy/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: go-philosophy
-description: Go言語の設計思想と哲学を理解し、Goらしいコードを書くためのガイド。「なぜGoはこう設計されたのか」を理解したいとき、Goのイディオムを学びたいときに使用。
+description: Guide to understanding Go's design philosophy and writing idiomatic Go code. Use when you want to understand "why Go is designed this way" or learn Go idioms.
 ---
 
-# Go の設計思想と哲学
+# Go Design Philosophy
 
-## 核となる原則
+## Core Principles
 
-### 1. シンプルさ (Simplicity)
+### 1. Simplicity
 
-Go は意図的に機能を制限しています。これは欠点ではなく、設計思想です。
+Go intentionally limits features. This is not a weakness, but a design philosophy.
 
 ```go
-// Good: シンプルで明確
+// Good: Simple and clear
 func Process(items []Item) error {
     for _, item := range items {
         if err := item.Validate(); err != nil {
@@ -22,7 +22,7 @@ func Process(items []Item) error {
     return nil
 }
 
-// Avoid: 過度な抽象化
+// Avoid: Excessive abstraction
 type Processor interface {
     Process(Processable) error
 }
@@ -31,29 +31,29 @@ type Processable interface {
 }
 ```
 
-**Rob Pike**: "少ないものでより多くを達成する"
+**Rob Pike**: "Do more with less"
 
-### 2. 明示性 (Explicitness)
+### 2. Explicitness
 
-Go は暗黙の動作を避け、コードの意図を明確にします。
+Go avoids implicit behavior and makes code intent clear.
 
 ```go
-// Good: エラーを明示的に処理
+// Good: Explicitly handle errors
 result, err := doSomething()
 if err != nil {
     return fmt.Errorf("doSomething failed: %w", err)
 }
 
-// Avoid: エラーを無視
-result, _ := doSomething()  // なぜ無視するのか不明
+// Avoid: Ignore errors
+result, _ := doSomething()  // Unclear why ignored
 ```
 
-### 3. 合成 (Composition over Inheritance)
+### 3. Composition over Inheritance
 
-Go には継承がありません。代わりに合成を使います。
+Go has no inheritance. Instead, use composition.
 
 ```go
-// Good: 埋め込みによる合成
+// Good: Composition via embedding
 type Logger struct {
     prefix string
 }
@@ -63,19 +63,19 @@ func (l *Logger) Log(msg string) {
 }
 
 type Server struct {
-    Logger  // 埋め込み
+    Logger  // Embedding
     addr string
 }
 
-// Server は Logger のメソッドを持つ
+// Server has Logger's methods
 server := &Server{Logger: Logger{prefix: "HTTP"}, addr: ":8080"}
-server.Log("Starting...")  // Logger.Log を呼び出し
+server.Log("Starting...")  // Calls Logger.Log
 ```
 
-### 4. インターフェースは小さく
+### 4. Small Interfaces
 
 ```go
-// Good: 単一メソッドのインターフェース
+// Good: Single-method interfaces
 type Reader interface {
     Read(p []byte) (n int, err error)
 }
@@ -84,30 +84,30 @@ type Writer interface {
     Write(p []byte) (n int, err error)
 }
 
-// 必要に応じて合成
+// Compose as needed
 type ReadWriter interface {
     Reader
     Writer
 }
 
-// Avoid: 大きなインターフェース
+// Avoid: Large interfaces
 type Everything interface {
     Read(p []byte) (n int, err error)
     Write(p []byte) (n int, err error)
     Close() error
     Seek(offset int64, whence int) (int64, error)
-    // ...多すぎる
+    // ...too many
 }
 ```
 
-## Go Proverbs (Go の格言)
+## Go Proverbs
 
-Rob Pike による Go の格言を理解しましょう。
+Understand Go proverbs by Rob Pike.
 
 ### "Don't communicate by sharing memory, share memory by communicating"
 
 ```go
-// Avoid: 共有メモリ + mutex
+// Avoid: Shared memory + mutex
 var (
     counter int
     mu      sync.Mutex
@@ -119,7 +119,7 @@ func increment() {
     mu.Unlock()
 }
 
-// Good: チャネルで通信
+// Good: Communicate via channels
 func counter(ch chan int) {
     count := 0
     for delta := range ch {
@@ -131,17 +131,17 @@ func counter(ch chan int) {
 ### "The bigger the interface, the weaker the abstraction"
 
 ```go
-// Weak: 大きなインターフェース
+// Weak: Large interface
 type UserService interface {
     Create(user User) error
     Update(user User) error
     Delete(id string) error
     Get(id string) (User, error)
     List() ([]User, error)
-    // 使う側は全メソッドに依存
+    // Users depend on all methods
 }
 
-// Strong: 必要最小限
+// Strong: Minimal necessary
 type UserCreator interface {
     Create(user User) error
 }
@@ -154,22 +154,22 @@ func RegisterUser(creator UserCreator, user User) error {
 ### "Make the zero value useful"
 
 ```go
-// Good: ゼロ値が有用
+// Good: Zero value is useful
 type Buffer struct {
     buf []byte
 }
 
 func (b *Buffer) Write(p []byte) (int, error) {
-    b.buf = append(b.buf, p...)  // nil スライスへの append は OK
+    b.buf = append(b.buf, p...)  // Append to nil slice is OK
     return len(p), nil
 }
 
-var buf Buffer  // 初期化なしで使える
+var buf Buffer  // Can use without initialization
 buf.Write([]byte("hello"))
 
-// sync.Mutex もゼロ値で使える
+// sync.Mutex is also usable with zero value
 var mu sync.Mutex
-mu.Lock()  // 初期化不要
+mu.Lock()  // No initialization needed
 ```
 
 ### "Clear is better than clever"
@@ -180,16 +180,16 @@ func f(n int) int { return n & (n - 1) }
 
 // Clear
 func clearLowestBit(n int) int {
-    return n & (n - 1)  // 最下位ビットをクリア
+    return n & (n - 1)  // Clear lowest bit
 }
 ```
 
-## エラー処理の哲学
+## Error Handling Philosophy
 
-### エラーは値である
+### Errors are Values
 
 ```go
-// エラーを値として扱う
+// Treat errors as values
 type PathError struct {
     Op   string
     Path string
@@ -205,25 +205,25 @@ func (e *PathError) Unwrap() error {
 }
 ```
 
-### エラーを装飾する
+### Decorate Errors
 
 ```go
 func ReadConfig(path string) (*Config, error) {
     data, err := os.ReadFile(path)
     if err != nil {
-        // コンテキストを追加
+        // Add context
         return nil, fmt.Errorf("read config %s: %w", path, err)
     }
     // ...
 }
 ```
 
-## 並行処理の哲学
+## Concurrency Philosophy
 
-### Goroutine は軽量
+### Goroutines are Lightweight
 
 ```go
-// goroutine を躊躇なく使う
+// Don't hesitate to use goroutines
 func processItems(items []Item) {
     var wg sync.WaitGroup
     for _, item := range items {
@@ -237,7 +237,7 @@ func processItems(items []Item) {
 }
 ```
 
-### Context でキャンセルを伝播
+### Propagate Cancellation with Context
 
 ```go
 func fetchData(ctx context.Context, url string) ([]byte, error) {
@@ -245,25 +245,25 @@ func fetchData(ctx context.Context, url string) ([]byte, error) {
     if err != nil {
         return nil, err
     }
-    // ctx がキャンセルされるとリクエストも中断
+    // Request is cancelled when ctx is cancelled
     resp, err := http.DefaultClient.Do(req)
     // ...
 }
 ```
 
-## パッケージ設計の哲学
+## Package Design Philosophy
 
-### 循環依存を避ける
+### Avoid Circular Dependencies
 
 ```
-// Good: 一方向の依存
+// Good: One-way dependency
 main → handler → service → repository
 
-// Avoid: 循環依存
-service → repository → service  // コンパイルエラー
+// Avoid: Circular dependency
+service → repository → service  // Compile error
 ```
 
-### パッケージ名は簡潔に
+### Keep Package Names Concise
 
 ```go
 // Good
@@ -275,7 +275,7 @@ import "encoding/jsonencoder"
 jsonencoder.Marshal(data)
 ```
 
-## 参考資料
+## References
 
 - [Effective Go](https://go.dev/doc/effective_go)
 - [Go Proverbs](https://go-proverbs.github.io/)

--- a/.claude/skills/go-testing/SKILL.md
+++ b/.claude/skills/go-testing/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: go-testing
-description: Goのテスト戦略とTDD実践ガイド。ユニットテスト、テーブル駆動テスト、モック、ベンチマークについて質問されたときに使用。
+description: Go testing strategy and TDD practice guide. Use when asked about unit tests, table-driven tests, mocks, or benchmarks.
 ---
 
-# Go テスト戦略
+# Go Testing Strategy
 
-## TDD サイクル
+## TDD Cycle
 
 ### Red → Green → Refactor
 
 ```go
-// 1. Red: 失敗するテストを書く
+// 1. Red: Write a failing test
 func TestAdd(t *testing.T) {
     result := Add(2, 3)
     if result != 5 {
@@ -18,31 +18,50 @@ func TestAdd(t *testing.T) {
     }
 }
 
-// 2. Green: 最小限の実装
+// 2. Green: Minimal implementation
 func Add(a, b int) int {
     return a + b
 }
 
-// 3. Refactor: 必要に応じてリファクタリング
+// 3. Refactor: Refactor as needed
 ```
 
-## テーブル駆動テスト
+## Table-Driven Tests
 
-### 基本パターン
+Table-driven tests define multiple test cases in table format and execute them in a loop.
+This is a standard Go testing approach that makes it easy to add test cases and avoids code duplication.
+
+**Benefits:**
+
+- Easy to add test cases
+- Avoids duplication of test logic
+- Easy to compare test cases
+- Can be executed individually with `t.Run`
+
+**When to use:**
+
+- When testing the same function with different inputs multiple times
+- When testing error cases and success cases with the same structure
+- When there are 5 or more test cases (fewer cases can use individual functions)
+
+### Basic Pattern
 
 ```go
 func TestCalculate(t *testing.T) {
+    // Define test cases in table format
     tests := []struct {
-        name     string
-        input    int
-        expected int
+        name     string  // Test case name (used with t.Run)
+        input    int     // Input value
+        expected int     // Expected value
     }{
         {"positive", 5, 10},
         {"zero", 0, 0},
         {"negative", -3, -6},
     }
 
+    // Execute each test case in a loop
     for _, tt := range tests {
+        // Execute as subtest with t.Run (can be executed and debugged individually)
         t.Run(tt.name, func(t *testing.T) {
             result := Calculate(tt.input)
             if result != tt.expected {
@@ -54,25 +73,34 @@ func TestCalculate(t *testing.T) {
 }
 ```
 
-### エラーケースを含む
+### Including Error Cases
+
+When testing functions that return errors, use the `wantErr` flag to explicitly indicate whether an error is expected.
+Managing error cases and success cases in the same table improves test coverage.
+
+**Common pitfalls:**
+
+- Forgetting `return` after error check causes subsequent assertions to execute
+- Easy to forget return value validation in `wantErr: true` cases (validate as needed)
 
 ```go
 func TestParseConfig(t *testing.T) {
     tests := []struct {
         name    string
         input   string
-        want    *Config
-        wantErr bool
+        want    *Config      // Expected value for success case
+        wantErr bool         // Whether error is expected
     }{
         {
             name:  "valid config",
             input: `{"port": 8080}`,
             want:  &Config{Port: 8080},
+            // wantErr: false is default
         },
         {
             name:    "invalid json",
             input:   `{invalid}`,
-            wantErr: true,
+            wantErr: true,  // Error expected
         },
         {
             name:    "empty input",
@@ -85,18 +113,21 @@ func TestParseConfig(t *testing.T) {
         t.Run(tt.name, func(t *testing.T) {
             got, err := ParseConfig(tt.input)
 
+            // Validate error case
             if tt.wantErr {
                 if err == nil {
                     t.Error("expected error, got nil")
                 }
-                return
+                return  // Early return for error case
             }
 
+            // Validate success case
             if err != nil {
                 t.Errorf("unexpected error: %v", err)
                 return
             }
 
+            // Validate return value
             if !reflect.DeepEqual(got, tt.want) {
                 t.Errorf("got %+v, want %+v", got, tt.want)
             }
@@ -105,13 +136,28 @@ func TestParseConfig(t *testing.T) {
 }
 ```
 
-## テストヘルパー
+## Test Helpers
+
+Test helper functions reduce duplication in test code and improve readability.
+Calling `t.Helper()` makes error messages point to the caller's line instead of inside the helper function.
+
+**Why `t.Helper()` is needed:**
+
+- Error messages point to the actual test code line
+- Makes it easier to identify problem locations during debugging
+- Test framework skips helper functions when generating stack traces
+
+**Common pitfalls:**
+
+- Forgetting to call `t.Helper()` makes error messages point inside helper function
+- When using `t.Fatal` in helper functions, always call `t.Helper()` first
 
 ### t.Helper()
 
 ```go
+// Helper functions must call t.Helper() first
 func assertEqual(t *testing.T, got, want int) {
-    t.Helper()  // エラー発生位置を呼び出し元に
+    t.Helper()  // Set error location to caller
     if got != want {
         t.Errorf("got %d, want %d", got, want)
     }
@@ -119,70 +165,114 @@ func assertEqual(t *testing.T, got, want int) {
 
 func TestSomething(t *testing.T) {
     result := Calculate(5)
-    assertEqual(t, result, 10)  // エラーはこの行を指す
+    // Error message points to this line (due to t.Helper())
+    assertEqual(t, result, 10)
 }
 ```
 
-### テスト用セットアップ
+### Test Setup
+
+Manage resource setup and cleanup with helper functions.
+Using `t.Cleanup()` ensures resources are released even if tests fail.
+
+**Best practices:**
+
+- Setup functions call `t.Helper()` first
+- Register resource cleanup with `t.Cleanup()`
+- Use `t.Fatalf` to immediately terminate tests on error
 
 ```go
 func setupTestDB(t *testing.T) *sql.DB {
-    t.Helper()
+    t.Helper()  // Mark as helper function
 
     db, err := sql.Open("sqlite3", ":memory:")
     if err != nil {
         t.Fatalf("failed to open db: %v", err)
     }
 
+    // Ensures cleanup when test ends
     t.Cleanup(func() {
-        db.Close()
+        if err := db.Close(); err != nil {
+            t.Logf("failed to close db: %v", err)
+        }
     })
 
     return db
 }
 
 func TestUserRepository(t *testing.T) {
-    db := setupTestDB(t)
+    db := setupTestDB(t)  // Delegate setup to helper
     repo := NewUserRepository(db)
-    // テスト...
+    // db.Close() is automatically called when test ends
 }
 ```
 
-## インターフェースとモック
+## Interfaces and Mocks
 
-### テスト可能な設計
+Using interfaces allows you to replace external dependencies (databases, APIs, file systems, etc.) with mocks.
+This makes tests fast, stable, and independent of production environments.
+
+**Principles of testable design:**
+
+- Abstract dependencies with interfaces
+- Inject dependencies through constructors (dependency injection)
+- Keep interfaces small with specific responsibilities
+
+**Mocks vs Integration Tests:**
+
+- Mocks: Fast, stable, suitable for unit tests
+- Integration tests: Test actual dependencies, slow but highly reliable
+- It's important to use both appropriately
+
+### Testable Design
 
 ```go
-// インターフェースを定義
+// Define interface (depend on interface, not implementation)
 type UserRepository interface {
     Get(id string) (*User, error)
     Save(user *User) error
 }
 
-// 本番実装
+// Production implementation (uses PostgreSQL)
 type PostgresUserRepository struct {
     db *sql.DB
 }
 
-// テスト用モック
+// Test mock (flexible behavior definition with function fields)
 type MockUserRepository struct {
     GetFunc  func(id string) (*User, error)
     SaveFunc func(user *User) error
 }
 
 func (m *MockUserRepository) Get(id string) (*User, error) {
-    return m.GetFunc(id)
+    if m.GetFunc != nil {
+        return m.GetFunc(id)
+    }
+    return nil, errors.New("GetFunc not set")
 }
 
 func (m *MockUserRepository) Save(user *User) error {
-    return m.SaveFunc(user)
+    if m.SaveFunc != nil {
+        return m.SaveFunc(user)
+    }
+    return errors.New("SaveFunc not set")
 }
 ```
 
-### モックの使用
+### Using Mocks
+
+Mocks allow testing business logic without depending on databases or external APIs.
+Define necessary behavior for each test case and keep tests independent.
+
+**How to use mocks:**
+
+- Define necessary behavior for each test case
+- Test error cases easily
+- Test multiple scenarios with subtests
 
 ```go
 func TestUserService_GetUser(t *testing.T) {
+    // Define mock repository (behavior can be customized per test case)
     mockRepo := &MockUserRepository{
         GetFunc: func(id string) (*User, error) {
             if id == "123" {
@@ -206,6 +296,7 @@ func TestUserService_GetUser(t *testing.T) {
 
     t.Run("not found", func(t *testing.T) {
         _, err := service.GetUser("999")
+        // Check error type with errors.Is
         if !errors.Is(err, ErrNotFound) {
             t.Errorf("got error %v, want ErrNotFound", err)
         }
@@ -213,12 +304,29 @@ func TestUserService_GetUser(t *testing.T) {
 }
 ```
 
-## サブテスト
+## Subtests
+
+Using `t.Run` allows logical grouping of tests and individual execution/debugging.
+Combined with table-driven tests, each test case can be executed independently.
+
+**Benefits:**
+
+- Logically group test cases
+- Execute specific subtests only (`go test -run TestMath/Addition`)
+- Organized test output makes it clear which cases failed
+- Can run in parallel (combined with `t.Parallel()`)
+
+**When to use:**
+
+- When grouping multiple related test cases
+- When executing each case individually in table-driven tests
+- When you want to clarify test structure
 
 ### t.Run
 
 ```go
 func TestMath(t *testing.T) {
+    // Group tests with subtests
     t.Run("Addition", func(t *testing.T) {
         t.Run("positive numbers", func(t *testing.T) {
             if Add(2, 3) != 5 {
@@ -233,12 +341,31 @@ func TestMath(t *testing.T) {
     })
 
     t.Run("Multiplication", func(t *testing.T) {
-        // ...
+        // Tests for another group
     })
 }
+
+// Execution examples:
+// go test -run TestMath                    // Run all
+// go test -run TestMath/Addition          // Addition group only
+// go test -run TestMath/Addition/positive // Specific subtest only
 ```
 
-### 並列テスト
+### Parallel Tests
+
+`t.Parallel()` allows running multiple tests in parallel.
+This shortens test execution time, but care is needed when accessing shared resources.
+
+**Notes:**
+
+- Always copy loop variables to local variables (`tt := tt`)
+- Avoid accessing shared resources (global variables, files, etc.)
+- Use independent instances for external resources like databases per test
+
+**Common pitfalls:**
+
+- Forgetting to capture loop variables causes all tests to use the same value
+- Accessing shared resources can cause race conditions
 
 ```go
 func TestParallel(t *testing.T) {
@@ -252,40 +379,83 @@ func TestParallel(t *testing.T) {
     }
 
     for _, tt := range tests {
-        tt := tt  // ループ変数をキャプチャ
+        tt := tt  // Important: Copy loop variable to local variable
         t.Run(tt.name, func(t *testing.T) {
-            t.Parallel()  // 並列実行
+            t.Parallel()  // Mark for parallel execution
             result := SlowOperation(tt.input)
             // assertions...
         })
     }
 }
+
+// Execution example:
+// go test -parallel 4  // Run up to 4 tests in parallel
 ```
 
-## ベンチマーク
+## Benchmarks
 
-### 基本
+Benchmark tests measure code performance.
+Run with `go test -bench` to compare execution time and memory usage.
+
+**How to use benchmarks:**
+
+- Detect performance regressions
+- Measure optimization effectiveness
+- Compare different implementations
+
+**Execution methods:**
+
+```bash
+go test -bench=.           # Run all benchmarks
+go test -bench=Fibonacci   # Specific benchmark only
+go test -bench=. -benchmem # Also show memory allocations
+```
+
+### Basic
 
 ```go
 func BenchmarkFibonacci(b *testing.B) {
+    // b.N is automatically adjusted by benchmark framework
+    // Executed repeatedly until sufficient statistical precision is achieved
     for i := 0; i < b.N; i++ {
         Fibonacci(20)
     }
 }
 ```
 
-### メモリアロケーション
+### Memory Allocation
+
+`b.ReportAllocs()` measures memory allocation count per iteration.
+Useful for tracking memory efficiency improvements.
+
+**Interpretation points:**
+
+- `allocs/op`: Allocation count per operation
+- `B/op`: Memory usage per operation (bytes)
+- 0 allocs/op is ideal, but consider practical trade-offs
 
 ```go
 func BenchmarkConcat(b *testing.B) {
-    b.ReportAllocs()  // メモリ割り当てを報告
+    b.ReportAllocs()  // Report memory allocation
     for i := 0; i < b.N; i++ {
         Concat("hello", "world")
     }
 }
+
+// Output example:
+// BenchmarkConcat-8    1000000    1200 ns/op    32 B/op    2 allocs/op
 ```
 
-### サブベンチマーク
+### Sub-benchmarks
+
+Define sub-benchmarks with `b.Run` to compare performance under different conditions.
+Effective for measuring scalability by varying data sizes or parameters.
+
+**Notes:**
+
+- Exclude setup time from measurement with `b.ResetTimer()`
+- Place setup like data generation before `b.ResetTimer()`
+- Each sub-benchmark runs independently
 
 ```go
 func BenchmarkSort(b *testing.B) {
@@ -293,30 +463,34 @@ func BenchmarkSort(b *testing.B) {
 
     for _, size := range sizes {
         b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+            // Setup (excluded from measurement)
             data := generateData(size)
-            b.ResetTimer()
+            b.ResetTimer()  // Start measurement from here
             for i := 0; i < b.N; i++ {
                 Sort(data)
             }
         })
     }
 }
+
+// Execution example:
+// go test -bench=BenchmarkSort/size=100
 ```
 
-## テストカバレッジ
+## Test Coverage
 
 ```bash
-# カバレッジ計測
+# Measure coverage
 go test -cover ./...
 
-# HTML レポート生成
+# Generate HTML report
 go test -coverprofile=coverage.out ./...
 go tool cover -html=coverage.out -o coverage.html
 ```
 
-## テスト用タグ
+## Test Tags
 
-### 統合テストの分離
+### Separating Integration Tests
 
 ```go
 //go:build integration
@@ -324,50 +498,76 @@ go tool cover -html=coverage.out -o coverage.html
 package mypackage
 
 func TestIntegration(t *testing.T) {
-    // 統合テスト
+    // Integration test
 }
 ```
 
 ```bash
-# 統合テストを実行
+# Run integration tests
 go test -tags=integration ./...
 
-# 統合テストを除外
+# Exclude integration tests
 go test ./...
 ```
 
-## ゴールデンファイル
+## Golden Files
+
+Golden file tests compare output with expected values stored in files.
+Effective when output is complex and changes frequently, such as HTML rendering, code generation, or configuration file formatting.
+
+**When to use:**
+
+- When output is large and manual assertions are difficult
+- When detecting output format changes
+- When functioning as regression tests
+
+**Notes:**
+
+- Golden files must be included in version control
+- Update with `-update` flag when making intentional changes
+- Always check file I/O errors
 
 ```go
+var update = flag.Bool("update", false, "update golden files")
+
 func TestRender(t *testing.T) {
     result := Render(input)
 
     golden := filepath.Join("testdata", t.Name()+".golden")
 
     if *update {
-        os.WriteFile(golden, []byte(result), 0644)
+        // Check error when updating golden file
+        if err := os.WriteFile(golden, []byte(result), 0644); err != nil {
+            t.Fatalf("failed to write golden file: %v", err)
+        }
+        return
     }
 
-    expected, _ := os.ReadFile(golden)
+    // Always check read errors for golden file
+    expected, err := os.ReadFile(golden)
+    if err != nil {
+        t.Fatalf("failed to read golden file: %v", err)
+    }
+
     if result != string(expected) {
         t.Errorf("output mismatch\ngot:\n%s\nwant:\n%s", result, expected)
     }
 }
 ```
 
-## アンチパターン
+## Anti-patterns
 
-### 1. テストでの sleep
+### 1. Sleep in Tests
 
 ```go
 // Avoid
 func TestAsync(t *testing.T) {
     go doSomething()
-    time.Sleep(1 * time.Second)  // 不安定
+    time.Sleep(1 * time.Second)  // Unstable
     // assert...
 }
 
-// Good: チャネルや WaitGroup で同期
+// Good: Synchronize with channels or WaitGroup
 func TestAsync(t *testing.T) {
     done := make(chan struct{})
     go func() {
@@ -379,10 +579,10 @@ func TestAsync(t *testing.T) {
 }
 ```
 
-### 2. テスト間の依存
+### 2. Test Dependencies
 
 ```go
-// Avoid: テストの実行順序に依存
+// Avoid: Dependent on test execution order
 var globalState int
 
 func TestA(t *testing.T) {
@@ -390,10 +590,293 @@ func TestA(t *testing.T) {
 }
 
 func TestB(t *testing.T) {
-    if globalState != 1 {  // TestA の後でないと失敗
+    if globalState != 1 {  // Fails unless TestA runs first
         t.Error("failed")
     }
 }
 
-// Good: 各テストで独立したセットアップ
+// Good: Independent setup for each test
+func TestB(t *testing.T) {
+    state := 1  // Manage independent state within test
+    if state != 1 {
+        t.Error("failed")
+    }
+}
+```
+
+### 3. Ignoring Errors
+
+```go
+// Avoid: Ignoring errors
+func TestReadFile(t *testing.T) {
+    data, _ := os.ReadFile("test.txt")  // Ignore error
+    // ...
+}
+
+// Good: Handle errors appropriately
+func TestReadFile(t *testing.T) {
+    data, err := os.ReadFile("test.txt")
+    if err != nil {
+        t.Fatalf("failed to read file: %v", err)
+    }
+    // ...
+}
+```
+
+### 4. Tests Too Slow
+
+```go
+// Avoid: Tests depending on production environment
+func TestAPI(t *testing.T) {
+    resp, err := http.Get("https://api.example.com/data")
+    // Network delay makes tests slow
+}
+
+// Good: Use mocks or test servers
+func TestAPI(t *testing.T) {
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte(`{"data": "test"}`))
+    }))
+    defer server.Close()
+
+    resp, err := http.Get(server.URL)
+    // Fast and stable test
+}
+```
+
+## Best Practices
+
+### Test Organization
+
+**File structure:**
+
+- Test files follow `*_test.go` naming convention
+- Test files are placed in the same package (`package mypackage`)
+- Integration tests are separated with `*_integration_test.go` or build tags
+
+**Naming conventions:**
+
+- Test functions start with `Test` (e.g., `TestCalculate`)
+- Benchmark functions start with `Benchmark` (e.g., `BenchmarkSort`)
+- Test case names should be descriptive (e.g., `"adds two positive numbers"` instead of `"positive numbers"`)
+
+**Test grouping:**
+
+```go
+// Group related tests in the same file
+// calculator_test.go
+func TestAdd(t *testing.T) { /* ... */ }
+func TestSubtract(t *testing.T) { /* ... */ }
+func TestMultiply(t *testing.T) { /* ... */ }
+
+// Tests for different features go in separate files
+// parser_test.go
+func TestParse(t *testing.T) { /* ... */ }
+```
+
+### Test Pattern Selection Guide
+
+**Table-driven tests vs Individual test functions:**
+
+| Situation                            | Recommended Pattern  | Reason                         |
+| ------------------------------------ | -------------------- | ------------------------------ |
+| 3 or fewer test cases                | Individual functions | Simple and readable            |
+| 4 or more test cases                 | Table-driven         | Avoid duplication, easy to add |
+| Many error cases                     | Table-driven         | Easy to cover error cases      |
+| Setup differs significantly per case | Individual functions | Table becomes too complex      |
+
+**Mocks vs Integration tests:**
+
+| Situation                | Recommended Approach      | Reason                           |
+| ------------------------ | ------------------------- | -------------------------------- |
+| Business logic testing   | Mocks                     | Fast and stable                  |
+| API contract testing     | Integration tests         | Verify actual behavior           |
+| Database schema testing  | Integration tests         | Detect schema changes            |
+| External service testing | Mocks + Integration tests | Test different aspects with both |
+
+**Golden files vs Assertions:**
+
+| Situation                   | Recommended Pattern | Reason                         |
+| --------------------------- | ------------------- | ------------------------------ |
+| Small, structured output    | Assertions          | Clear and readable             |
+| Large, complex output       | Golden files        | Manual assertions difficult    |
+| HTML/XML/JSON generation    | Golden files        | Detect format changes          |
+| Numeric calculation results | Assertions          | Numeric comparison appropriate |
+
+### Error Handling Best Practices
+
+**Error handling in tests:**
+
+1. **Always check I/O operation errors:**
+
+```go
+// Good
+data, err := os.ReadFile("test.txt")
+if err != nil {
+    t.Fatalf("failed to read file: %v", err)
+}
+
+// Avoid
+data, _ := os.ReadFile("test.txt")
+```
+
+2. **Fail immediately on setup errors with `t.Fatalf`:**
+
+```go
+func setupTestDB(t *testing.T) *sql.DB {
+    t.Helper()
+    db, err := sql.Open("sqlite3", ":memory:")
+    if err != nil {
+        t.Fatalf("failed to open db: %v", err)  // Terminate immediately on setup failure
+    }
+    return db
+}
+```
+
+3. **Validate errors under test appropriately:**
+
+```go
+// When error is expected
+if err == nil {
+    t.Error("expected error, got nil")
+}
+
+// When error is not expected
+if err != nil {
+    t.Fatalf("unexpected error: %v", err)
+}
+
+// Validate specific error
+if !errors.Is(err, ErrNotFound) {
+    t.Errorf("got error %v, want ErrNotFound", err)
+}
+```
+
+4. **Clear error messages:**
+
+```go
+// Good: Clearly state what was expected and what was got
+if got != want {
+    t.Errorf("Calculate(%d) = %d, want %d", input, got, want)
+}
+
+// Avoid: Vague messages
+if got != want {
+    t.Error("failed")
+}
+```
+
+### Test Maintainability
+
+**Ways to maintain test code quality:**
+
+1. **Keep tests independent:**
+
+   - Don't share state between tests
+   - Perform necessary setup in each test
+   - Avoid dependencies on global variables
+
+2. **Make tests readable:**
+
+   - Use descriptive test names
+   - Make test case names clear about what's being tested
+   - Extract complex logic into helper functions
+
+3. **Keep tests concise:**
+
+   - Test one thing per test
+   - Consider splitting if tests are too long
+   - Remove unnecessary assertions
+
+4. **Keep tests stable:**
+
+   - Avoid time-dependent tests (use channels instead of `time.Sleep`)
+   - Fix seed when using random values
+   - Minimize dependencies on external resources
+
+5. **Keep tests fast:**
+   - Avoid external dependencies with mocks
+   - Use `t.Parallel()` for parallelizable tests
+   - Minimize heavy setup
+
+**Test refactoring:**
+
+```go
+// Before: Too much duplication
+func TestAddPositive(t *testing.T) {
+    result := Add(2, 3)
+    if result != 5 {
+        t.Error("failed")
+    }
+}
+
+func TestAddNegative(t *testing.T) {
+    result := Add(-2, -3)
+    if result != -5 {
+        t.Error("failed")
+    }
+}
+
+// After: Refactored with table-driven test
+func TestAdd(t *testing.T) {
+    tests := []struct {
+        name     string
+        a        int
+        b        int
+        expected int
+    }{
+        {"positive", 2, 3, 5},
+        {"negative", -2, -3, -5},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := Add(tt.a, tt.b)
+            if result != tt.expected {
+                t.Errorf("Add(%d, %d) = %d, want %d",
+                    tt.a, tt.b, result, tt.expected)
+            }
+        })
+    }
+}
+```
+
+### 3. Ignoring Errors
+
+```go
+// Avoid: Ignoring errors
+func TestReadFile(t *testing.T) {
+    data, _ := os.ReadFile("test.txt")  // Ignore error
+    // ...
+}
+
+// Good: Handle errors appropriately
+func TestReadFile(t *testing.T) {
+    data, err := os.ReadFile("test.txt")
+    if err != nil {
+        t.Fatalf("failed to read file: %v", err)
+    }
+    // ...
+}
+```
+
+### 4. Tests Too Slow
+
+```go
+// Avoid: Tests depending on production environment
+func TestAPI(t *testing.T) {
+    resp, err := http.Get("https://api.example.com/data")
+    // Network delay makes tests slow
+}
+
+// Good: Use mocks or test servers
+func TestAPI(t *testing.T) {
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte(`{"data": "test"}`))
+    }))
+    defer server.Close()
+
+    resp, err := http.Get(server.URL)
+    // Fast and stable test
+}
 ```


### PR DESCRIPTION
## Overview

Translate all Go-related skill and command documentation from Japanese to English for consistency with agent-facing content.

## Purpose

Ensure all developer-facing documentation (skills and commands) are in English to maintain consistency with the project's internationalization efforts and improve accessibility for non-Japanese speakers.

## Implementation Summary

- Translate `.claude/commands/go-explain.md` - Go code explanation command
- Translate `.claude/commands/go-review.md` - Go code review command
- Translate `.claude/skills/go-code-review/SKILL.md` - Code review checklist and best practices
- Translate `.claude/skills/go-concurrency/SKILL.md` - Concurrency patterns and best practices
- Translate `.claude/skills/go-error-handling/SKILL.md` - Error handling patterns and best practices
- Translate `.claude/skills/go-philosophy/SKILL.md` - Go design philosophy guide
- Translate `.claude/skills/go-testing/SKILL.md` - Testing strategy and TDD practice guide

## Changes Result

- 7 files changed
- 897 insertions(+), 387 deletions(-)
- All documentation now in English while maintaining technical accuracy

## Areas for Review

- Are the translations accurate and maintain the original technical meaning?
- Is the English natural and clear?
- Are there any inconsistencies in terminology?

## Related

- Follows the pattern established in PR #21 (Convert all agent-facing content to English)
- Closes #28 (Enhance go-testing skill documentation with error handling and best practices)