### PR TITLE
docs: Fix marketplace command and add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ golang/go の Change (CL) を Claude Code で自動取得・分析し、Go の�
 
 ```bash
 # 1. マーケットプレイスを追加
-/plugin marketplace add DaisukeKarasawa/upgo
+/plugin marketplace add daisukekarasawa/upgo
 
 # 2. プラグインをインストール
 /plugin install go-pr-insights@daisukekarasawa-upgo

--- a/README.md
+++ b/README.md
@@ -42,6 +42,33 @@ golang/go の Change (CL) を Claude Code で自動取得・分析し、Go の�
 2. **Discover** タブで `go-pr-insights` を検索
 3. プラグインを選択してインストール
 
+#### トラブルシューティング
+
+マーケットプレイス追加時に以下のエラーが発生した場合：
+
+```
+Error: Failed to finalize marketplace cache. Please manually delete the directory at
+/Users/daisuke/.claude/plugins/marketplaces/daisukekarasawa-upgo if it exists and try again.
+
+Technical details: ENOENT: no such file or directory, rename
+'/Users/daisuke/.claude/plugins/marketplaces/DaisukeKarasawa-upgo' ->
+'/Users/daisuke/.claude/plugins/marketplaces/daisukekarasawa-upgo'
+```
+
+**原因**: macOSのデフォルトファイルシステム（APFS）は大文字小文字を区別しないため、大小文字のみが異なるディレクトリ名への `rename` 操作が失敗することがあります。
+
+**解決方法**:
+
+1. キャッシュディレクトリを削除：
+   ```bash
+   rm -rf ~/.claude/plugins/marketplaces/daisukekarasawa-upgo
+   rm -rf ~/.claude/plugins/marketplaces/DaisukeKarasawa-upgo
+   ```
+2. 小文字のowner名で再実行（推奨）：
+   ```bash
+   /plugin marketplace add daisukekarasawa/upgo
+   ```
+
 ### 方法2: 手動コピー
 
 ```bash


### PR DESCRIPTION
## Overview

Fix marketplace command owner name casing and add troubleshooting section for macOS APFS filesystem issue.

## Purpose

- Fix marketplace command to use correct owner name format (lowercase)
- Add troubleshooting documentation for users encountering APFS case-insensitivity issues

## Implementation Summary

- Fix marketplace command owner name from `DaisukeKarasawa` to `daisukekarasawa` to match actual marketplace format
- Add troubleshooting section explaining macOS APFS case-insensitive filesystem issue
- Document ENOENT rename error scenario and resolution steps

## Changes Result

- Marketplace command now uses correct lowercase owner name
- Users can reference troubleshooting section when encountering APFS-related errors

## Related

- Related to marketplace installation instructions added in PR #58

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/daisukekarasawa/upgo/pull/59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation example with corrected marketplace owner formatting.
  * Added Troubleshooting section addressing marketplace cache errors with two resolution approaches.
  * Added alternative manual installation method for users preferring direct repository setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->